### PR TITLE
modify recommand tracks

### DIFF
--- a/src/api/datasources/interfaces/index.ts
+++ b/src/api/datasources/interfaces/index.ts
@@ -2,6 +2,10 @@ export interface MusixmatchTrackWrapperObject {
   track: MusixmatchTrack
 }
 
+export interface MusixmatchAlbumWrapperObject {
+  album: MusixmatchAlbum
+}
+
 export interface MusixmatchTrack {
   track_id: number
   track_name: string

--- a/src/api/datasources/musixmatch.ts
+++ b/src/api/datasources/musixmatch.ts
@@ -2,6 +2,7 @@ import { RESTDataSource, RequestOptions } from 'apollo-datasource-rest'
 import { Track, Lyrics } from 'shared/interfaces'
 import {
   MusixmatchTrackWrapperObject,
+  MusixmatchAlbumWrapperObject,
   MusixmatchTrack,
   MusixmatchLyrics,
   MusixmatchAlbum,
@@ -132,17 +133,28 @@ class MusixmatchAPI extends RESTDataSource {
     return this.lyricsReducer(body.lyrics)
   }
 
-  async getTracksByAlbumId({ albumId }: { albumId: number }) {
-    const body = await this.get('album.tracks.get', {
-      page_size: 5,
+  async getTracksByAlbumId({ albumId, size }: { albumId: number, size: number }) {
+    if (size){
+      const body = await this.get('album.tracks.get', {
+      page_size: size,
       album_id: albumId,
       f_has_lyrics: true,
     })
-
-    const trackList: MusixmatchTrackWrapperObject[] = body.track_list
-    return Array.isArray(trackList)
-      ? trackList.map((track) => this.trackReducer(track.track))
-      : []
+      const trackList: MusixmatchTrackWrapperObject[] = body.track_list
+      return Array.isArray(trackList)
+        ? trackList.map((track) => this.trackReducer(track.track))
+        : []
+    }
+    else{
+      const body = await this.get('album.tracks.get', {
+        album_id: albumId,
+        f_has_lyrics: true,
+      })
+      const trackList: MusixmatchTrackWrapperObject[] = body.track_list
+      return Array.isArray(trackList)
+        ? trackList.map((track) => this.trackReducer(track.track))
+        : []
+    }  
   }
 
   async getAlbumById({ albumId }: { albumId: number }) {
@@ -151,6 +163,18 @@ class MusixmatchAPI extends RESTDataSource {
     })
 
     return this.albumReducer(body.album)
+  }
+
+  async getAlbumsByArtistId({ artistId } : {artistId : number}){
+    const body = await this.get('artist.albums.get',{
+      artist_id: artistId,
+      s_release_date: 'desc',
+    })
+
+    const albumList: MusixmatchAlbumWrapperObject[] = body.album_list
+      return Array.isArray(albumList)
+        ? albumList.map((track) => this.albumReducer(track.album))
+        : []
   }
 }
 

--- a/src/api/resolvers.js
+++ b/src/api/resolvers.js
@@ -51,29 +51,55 @@ module.exports = {
     },
     recommandTracks: async (_, { artistId, albumId }, { dataSources }) => {
       if (artistId && albumId) {
-        const allTracks =
-          (await dataSources.musixmatchAPI.searchTracks({
+        const sameAlbumTracks =
+          (await dataSources.musixmatchAPI.getTracksByAlbumId({
+            albumId: albumId,
+          })) ?? []
+        const needSize = 20 - sameAlbumTracks.length + 1
+        if (needSize <= 0){
+          return sameAlbumTracks
+        }
+        const allAlbums = (await dataSources.musixmatchAPI.getAlbumsByArtistId({
             artistId: artistId,
           })) ?? []
-        const otherTracks =
+        let selectAlbum = allAlbums[Math.floor(Math.random() * allAlbums.length)]
+        if (selectAlbum.id !== albumId){
+          const otherTracks = (await dataSources.musixmatchAPI.getTracksByAlbumId({
+          size: needSize,
+          albumId: selectAlbum.id,
+          }))
+          otherTracks.push(...sameAlbumTracks)
+          return otherTracks
+        }
+        else{
+          selectAlbum = allAlbums[Math.floor(Math.random() * allAlbums.length)]
+          const otherTracks = (await dataSources.musixmatchAPI.getTracksByAlbumId({
+            size: needSize,
+            albumId: selectAlbum.id,
+            }))
+          otherTracks.push(...sameAlbumTracks)
+          return otherTracks
+        }
+      } 
+      else if (!artistId && albumId) {
+        const sameAlbumTracks =
           (await dataSources.musixmatchAPI.getTracksByAlbumId({
             albumId: albumId,
           })) ?? []
-        allTracks.push(...otherTracks)
-        return allTracks
-      } else if (!artistId && albumId) {
-        const otherTracks =
-          (await dataSources.musixmatchAPI.getTracksByAlbumId({
-            albumId: albumId,
-          })) ?? []
+        return sameAlbumTracks
+      } 
+      else if (artistId && !albumId) {
+        const allAlbums = (await dataSources.musixmatchAPI.getAlbumsByArtistId({
+          artistId: artistId,
+        })) ?? []
+        const selectAlbum = allAlbums[Math.floor(Math.random() * allAlbums.length)]
+        const otherTracks = (await dataSources.musixmatchAPI.getTracksByAlbumId({
+        size: needSize,
+        albumId: selectAlbum.id,
+        }))
         return otherTracks
-      } else if (artistId && !albumId) {
-        const allTracks =
-          (await dataSources.musixmatchAPI.searchTracks({
-            artistId: artistId,
-          })) ?? []
-        return allTracks
-      } else {
+      } 
+      else {
         return []
       }
     },

--- a/src/pages/tracks/[id].tsx
+++ b/src/pages/tracks/[id].tsx
@@ -54,9 +54,10 @@ const TrackPage = () => {
   const [getRecommand, recommandTracksRes] =
     useLazyQuery<GetRecommandTracks>(GET_RECOMMAND_TRACKS)
 
-  const tracksList = recommandTracksRes.loading
+  const tracksListOri = recommandTracksRes.loading
     ? []
     : recommandTracksRes?.data?.recommandTracks
+  const tracksList = tracksListOri?.filter(track => track.id !== trackId.toString())
   // const album_name: string = trackRes?.data?.message?.body?.track?.album_name || ''
 
   const [insertTypingRecord] = useMutation<InsertTypingRecordOne>(


### PR DESCRIPTION
調整recommand tracks部分，包含same album的其他tracks跟隨機挑取的其他album的tracks，為了避免太長包含最多只會有20筆tracks，實際呈現不一定就是20筆取決於其他album的tracks數量。

有些情況下可能不會呈現出recommand tracks，像是same album為單曲且隨機挑選的其他album的tracks沒有lyrics。